### PR TITLE
Demonstrated proof of SOLID principle 3

### DIFF
--- a/src/Payment.cpp
+++ b/src/Payment.cpp
@@ -5,6 +5,11 @@
 #include <algorithm>
 using namespace std;
 
+//payment class shows SOLID-3 LSP principle that talks about a superclass being replaceable with its subclass
+//this replacement shouldn't affect the functioning of the program in any way
+
+//the class OnlinePayment(derived) can be substituted wherever the Payment class (base) is expected
+//this won't negatively affect the program hence also demonstrating the presence of LSP in the code
 class Payment {
 public:
     virtual void processPayment(int choice) {


### PR DESCRIPTION
I have added a comment where the code is demonstrating LSP - SOLID Principle 3.

In Payment.cpp, Payment class can be easily substituted with its subclass OnlinePayment without affecting the correctness of the program. This explains how Liskov's Substitution Principle is applied in the code.